### PR TITLE
Exclude node_modules from dependency_processor

### DIFF
--- a/cline_utils/dependency_system/dependency_processor.py
+++ b/cline_utils/dependency_system/dependency_processor.py
@@ -323,8 +323,8 @@ def generate_embeddings(root_paths: List[str], output_dir: str, model_name: str 
     file_count = 0
 
     # Define exclusions
-    EXCLUDED_DIRS = {".venv", ".git", "__pycache__"}
-    EXCLUDED_EXTS = {".sqlite3", ".bin", ".pyc", ".pyo", ".pyd"}
+    EXCLUDED_DIRS = {".venv", ".git", "__pycache__", "node_modules"}
+    EXCLUDED_EXTS = {".sqlite3", ".bin", ".pyc", ".pyo", ".pyd", ".jpg", ".png", ".mp3", ".ttf", ".ico", ".jpeg", ".wav"}
 
     if os.path.exists(metadata_file):
         try:


### PR DESCRIPTION
Exclude node_modules from dependency_processor
Also exclude more binary files