### PR TITLE
Fix:  consistent key ordering for grid_validation cache invalidation

### DIFF
--- a/cline_utils/dependency_system/core/dependency_grid.py
+++ b/cline_utils/dependency_system/core/dependency_grid.py
@@ -272,7 +272,11 @@ def remove_dependency_from_grid(grid: Dict[str, str], source_key: str, target_ke
     new_row = row[:target_idx] + EMPTY_CHAR + row[target_idx + 1:]
     new_grid[source_key] = compress(new_row)
     invalidate_dependent_entries('grid_decompress', f"decompress:{new_grid[source_key]}")
-    invalidate_dependent_entries('grid_validation', f"validate_grid:{hash(str(sorted(new_grid.items())))}:{':'.join(keys)}")
+    sorted_keys = sort_key_strings_hierarchically(keys)
+    invalidate_dependent_entries(
+        'grid_validation',
+        f"validate_grid:{hash(str(sorted(new_grid.items())))}:{':'.join(sorted_keys)}"
+    )
     return new_grid
 
 # --- Dependency Retrieval ---


### PR DESCRIPTION
Updated the `remove_dependency_from_grid` function in `dependency_grid.py` to sort keys hierarchically before cache invalidation. This change enhances the reliability of grid validation by ensuring consistent key ordering, an issue i was facing few days ago.